### PR TITLE
Fix issue #14, and general cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.paradoxical</groupId>
     <artifactId>dropwizard-swagger</artifactId>
-    <version>2.4${revision}</version>
+    <version>3.0${revision}</version>
     <packaging>jar</packaging>
     <description>Swagger management on the admin resource for dropwizard</description>
     <name>dropwizard-swagger</name>

--- a/src/main/java/io/paradoxical/dropwizard/swagger/DefaultSwaggerResourcesLocator.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/DefaultSwaggerResourcesLocator.java
@@ -3,30 +3,42 @@ package io.paradoxical.dropwizard.swagger;
 import io.paradoxical.dropwizard.swagger.resources.SwaggerApiResource;
 import io.paradoxical.dropwizard.swagger.resources.SwaggerUIResource;
 import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.models.Swagger;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 
+import javax.annotation.Nonnull;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Context;
 
 public class DefaultSwaggerResourcesLocator implements SwaggerResourcesLocator {
 
     @Getter
+    @Nonnull
     private final BeanConfig swaggerConfig;
+
+    @Getter
+    @Nonnull
+    private final Swagger defaultSwaggerModel;
 
     @Context
     @Getter
     @Setter
+    @Nonnull
+    @SuppressWarnings("NullableProblems")
     private ServletContext context;
 
-    public DefaultSwaggerResourcesLocator(@NonNull final BeanConfig swaggerConfig) {
+    public DefaultSwaggerResourcesLocator(
+            @NonNull @Nonnull final BeanConfig swaggerConfig,
+            final Swagger defaultSwaggerModel) {
         this.swaggerConfig = swaggerConfig;
+        this.defaultSwaggerModel = defaultSwaggerModel;
     }
 
     @Override
     public SwaggerApiResource api() {
-        return new SwaggerApiResource(getSwaggerConfig(), getContext());
+        return new SwaggerApiResource(getSwaggerConfig(), getContext(), getDefaultSwaggerModel());
     }
 
     @Override

--- a/src/main/java/io/paradoxical/dropwizard/swagger/EnvironmentSwaggerConfiguration.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/EnvironmentSwaggerConfiguration.java
@@ -18,27 +18,25 @@ public abstract class EnvironmentSwaggerConfiguration extends SwaggerConfigurati
      * Creates an environment specific swagger configuration,
      * optionally defaulting the swagger base path.
      * See the {@link BeanConfig#setBasePath(String)} method for details.
-     * @param environment the environment
+     *
+     * @param environment     the environment
      * @param contextSelector the environment servlet context selector to get the base path from
      *                        using the {@link MutableServletContextHandler#getContextPath()} method.
-     *                        @apiNote usually this will be one of either
-     *                          {@link Environment#getAdminContext() Environment::getAdminContext}
-     *                          or {@link Environment#getApplicationContext() Environment::getApplicationContext}
-     *
      */
     protected EnvironmentSwaggerConfiguration(
-        @Nullable final Environment environment,
-        @Nullable final Function<Environment, MutableServletContextHandler> contextSelector) {
+            @Nullable final Environment environment,
+            @Nullable final Function<Environment, MutableServletContextHandler> contextSelector) {
 
         this.environment = environment;
 
         if (environment != null) {
 
-            if(contextSelector == null) {
+            if (contextSelector == null) {
                 throw new IllegalArgumentException("contextSelector is null but the environment is null null");
             }
 
-            setBasePath(contextSelector.apply(environment).getContextPath());
+            setBasePath(contextSelector.apply(environment)
+                                       .getContextPath());
         }
     }
 }

--- a/src/main/java/io/paradoxical/dropwizard/swagger/SwaggerResourcesLocator.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/SwaggerResourcesLocator.java
@@ -3,6 +3,7 @@ package io.paradoxical.dropwizard.swagger;
 import io.dropwizard.setup.Environment;
 import io.paradoxical.dropwizard.swagger.resources.SwaggerApiResource;
 import io.paradoxical.dropwizard.swagger.resources.SwaggerUIResource;
+import io.swagger.models.Swagger;
 
 import javax.ws.rs.Path;
 
@@ -14,7 +15,8 @@ public interface SwaggerResourcesLocator {
     @Path("/ui")
     SwaggerUIResource ui();
 
+    @FunctionalInterface
     interface Factory {
-        SwaggerResourcesLocator forEnvironment(Environment environment);
+        SwaggerResourcesLocator create(Environment environment, Swagger defaultSwagger);
     }
 }

--- a/src/main/java/io/paradoxical/dropwizard/swagger/SwaggerUIConfigurator.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/SwaggerUIConfigurator.java
@@ -9,46 +9,88 @@ import io.dropwizard.views.mustache.MustacheViewRenderer;
 import io.paradoxical.dropwizard.bundles.admin.AdminEnvironmentConfigurator;
 import io.paradoxical.dropwizard.bundles.admin.AdminResourceEnvironment;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
+import io.swagger.models.Swagger;
 import lombok.NonNull;
 
+import javax.annotation.Nonnull;
 import java.util.function.Function;
 
 public class SwaggerUIConfigurator implements AdminEnvironmentConfigurator {
     private final SwaggerResourcesLocator.Factory swaggerResourcesLocatorFactory;
+    private final Swagger defaultSwaggerModel;
+
+    @SuppressWarnings("WeakerAccess")
+    public SwaggerUIConfigurator(
+            @NonNull @Nonnull final SwaggerResourcesLocator.Factory swaggerResourcesLocatorFactory,
+            final Swagger defaultSwaggerModel) {
+        this.swaggerResourcesLocatorFactory = swaggerResourcesLocatorFactory;
+        this.defaultSwaggerModel = defaultSwaggerModel;
+    }
 
     @SuppressWarnings("WeakerAccess")
     public SwaggerUIConfigurator(@NonNull final SwaggerResourcesLocator.Factory swaggerResourcesLocatorFactory) {
-        this.swaggerResourcesLocatorFactory = swaggerResourcesLocatorFactory;
+        this(swaggerResourcesLocatorFactory, null);
     }
 
     @SuppressWarnings("WeakerAccess")
     public SwaggerUIConfigurator(@NonNull final SwaggerResourcesLocator swaggerResourcesLocator) {
-        this(env -> swaggerResourcesLocator);
+        this((env, defaultSwagger) -> swaggerResourcesLocator);
     }
 
     @SuppressWarnings("unused")
-    public static SwaggerUIConfigurator forConfig(@NonNull final SwaggerConfiguration swaggerConfiguration) {
-        return new SwaggerUIConfigurator(new DefaultSwaggerResourcesLocator(swaggerConfiguration));
+    public SwaggerUIConfigurator(
+            @NonNull @Nonnull final SwaggerConfiguration swaggerConfiguration,
+            final Swagger defaultSwaggerModel) {
+        this(new DefaultSwaggerResourcesLocator(swaggerConfiguration, defaultSwaggerModel));
     }
 
     @SuppressWarnings("unused")
-    public static SwaggerUIConfigurator forConfig(@NonNull final Function<Environment, SwaggerConfiguration> envConfigFunction) {
-        return new SwaggerUIConfigurator(env -> new DefaultSwaggerResourcesLocator(envConfigFunction.apply(env)));
+    public SwaggerUIConfigurator(
+            @NonNull @Nonnull final SwaggerConfiguration swaggerConfiguration) {
+        this(swaggerConfiguration, null);
+    }
+
+    @SuppressWarnings("unused")
+    public SwaggerUIConfigurator(
+            @NonNull @Nonnull final Function<Environment, SwaggerConfiguration> envConfigFunction,
+            final Swagger defaultSwaggerModel) {
+        this(createDefaultFactory(envConfigFunction), defaultSwaggerModel);
+    }
+
+    @SuppressWarnings("unused")
+    public SwaggerUIConfigurator(
+            @NonNull @Nonnull final Function<Environment, SwaggerConfiguration> envConfigFunction) {
+        this(envConfigFunction, null);
+    }
+
+    private static SwaggerResourcesLocator.Factory createDefaultFactory(
+            final Function<Environment, SwaggerConfiguration> envConfigFunction) {
+        return new SwaggerResourcesLocator.Factory() {
+            @Override
+            public SwaggerResourcesLocator create(final Environment env, final Swagger defaultSwagger) {
+
+                final SwaggerConfiguration swaggerConfig = envConfigFunction.apply(env);
+
+                return new DefaultSwaggerResourcesLocator(swaggerConfig, defaultSwagger);
+            }
+        };
     }
 
     public void configure(Environment environment, JerseyEnvironment jerseyEnvironment) {
 
         final ViewMessageBodyWriter viewMessageBodyWriter =
-            new ViewMessageBodyWriter(environment.metrics(),
-                                      ImmutableList.of(new MustacheViewRenderer()));
+                new ViewMessageBodyWriter(environment.metrics(),
+                                          ImmutableList.of(new MustacheViewRenderer()));
 
         jerseyEnvironment.register(viewMessageBodyWriter);
         jerseyEnvironment.register(new SwaggerSerializers());
-        jerseyEnvironment.register(swaggerResourcesLocatorFactory.forEnvironment(environment));
+        jerseyEnvironment.register(swaggerResourcesLocatorFactory.create(environment, defaultSwaggerModel));
     }
 
+
     @Override
-    public void configure(Configuration configuration, AdminResourceEnvironment adminResourceEnvironment) {
-        AdminEnvironmentConfigurator.forJersey(this::configure).configure(configuration, adminResourceEnvironment);
+    public void configure(final Configuration config, final AdminResourceEnvironment adminResourceEnvironment) {
+        AdminEnvironmentConfigurator.forJersey(this::configure)
+                                    .configure(config, adminResourceEnvironment);
     }
 }

--- a/src/main/java/io/paradoxical/dropwizard/swagger/bundles/SwaggerUIBundle.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/bundles/SwaggerUIBundle.java
@@ -4,8 +4,12 @@ import io.dropwizard.setup.Environment;
 import io.paradoxical.dropwizard.bundles.assets.AssetsDefinition;
 import io.paradoxical.dropwizard.bundles.assets.AssetsDefinitionBundle;
 import io.paradoxical.dropwizard.swagger.SwaggerAssets;
+import io.paradoxical.dropwizard.swagger.SwaggerConfiguration;
 import io.paradoxical.dropwizard.swagger.SwaggerUIConfigurator;
 import lombok.NonNull;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
 
 public class SwaggerUIBundle extends AssetsDefinitionBundle {
 
@@ -18,6 +22,17 @@ public class SwaggerUIBundle extends AssetsDefinitionBundle {
     public SwaggerUIBundle(@NonNull final AssetsDefinition assets, @NonNull final SwaggerUIConfigurator swaggerUIConfigurator) {
         super(assets);
         this.swaggerUIConfigurator = swaggerUIConfigurator;
+    }
+
+    //
+    // Simplified common constructors
+    //
+    public SwaggerUIBundle(@NonNull @Nonnull final SwaggerConfiguration swaggerConfiguration) {
+        this(SwaggerAssets.Assets, new SwaggerUIConfigurator(swaggerConfiguration));
+    }
+
+    public SwaggerUIBundle(@NonNull @Nonnull final Function<Environment, SwaggerConfiguration> envConfigFunction) {
+        this(SwaggerAssets.Assets, new SwaggerUIConfigurator(envConfigFunction));
     }
 
     @Override

--- a/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIResource.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIResource.java
@@ -1,6 +1,5 @@
 package io.paradoxical.dropwizard.swagger.resources;
 
-import io.dropwizard.views.View;
 import io.paradoxical.dropwizard.swagger.SwaggerAssets;
 import lombok.Getter;
 
@@ -21,8 +20,17 @@ public class SwaggerUIResource {
     @Getter
     private final String dropwizardSwaggerViewResourcePath = SwaggerAssets.DROPWIZARD_SWAGGER_ASSET_ROOT + "/swagger.mustache";
 
+    @Getter
+    private final String defaultSwaggerJsonPath = "../api/swagger.json";
+
+    @Getter
+    private final boolean useJsonEditor = false;
+
     @GET
-    public View handleSwagger() {
-        return new View(getDropwizardSwaggerViewResourcePath()) {};
+    public SwaggerUIView handleSwagger() {
+
+        return new SwaggerUIView(getDropwizardSwaggerViewResourcePath(),
+                                 getDefaultSwaggerJsonPath(),
+                                 isUseJsonEditor());
     }
 }

--- a/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIResource.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIResource.java
@@ -9,6 +9,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+/**
+ * This class is responsible for selecting the view to render for the swagger ui
+ *
+ * @apiNote the {@link #getDropwizardSwaggerViewResourcePath()} method can be overridden to change the view resource path.
+ */
 @Path("/")
 @Produces(MediaType.TEXT_HTML)
 public class SwaggerUIResource {

--- a/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIView.java
+++ b/src/main/java/io/paradoxical/dropwizard/swagger/resources/SwaggerUIView.java
@@ -1,0 +1,28 @@
+package io.paradoxical.dropwizard.swagger.resources;
+
+import io.dropwizard.views.View;
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.annotation.Nonnull;
+
+@Getter
+public class SwaggerUIView extends View {
+
+    @Nonnull
+    private final String defaultSwaggerJsonPath;
+
+    @Nonnull
+    private final boolean useJsonEditor;
+
+    public SwaggerUIView(
+            @NonNull @Nonnull final String swaggerViewResourcePath,
+            @NonNull @Nonnull final String defaultSwaggerJsonPath,
+            final boolean useJsonEditor) {
+
+        super(swaggerViewResourcePath);
+
+        this.defaultSwaggerJsonPath = defaultSwaggerJsonPath;
+        this.useJsonEditor = useJsonEditor;
+    }
+}

--- a/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminOnly.java
+++ b/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminOnly.java
@@ -1,0 +1,16 @@
+package io.paradoxical.dropwizard.swagger.sample;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AdminOnly {
+
+}

--- a/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminTestResource.java
+++ b/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminTestResource.java
@@ -1,0 +1,34 @@
+package io.paradoxical.dropwizard.swagger.sample;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/test")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "Test")
+@AdminOnly
+public class AdminTestResource {
+
+    public AdminTestResource() {
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(
+        value = "says hello",
+        response = Object.class
+    )
+    public Response sayHello(@QueryParam("name") String name) {
+        return Response.ok(new Object(){
+            public final String helloMessage = "Hello " + name;
+        }).build();
+    }
+}

--- a/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminTestResource.java
+++ b/src/test/java/io/paradoxical/dropwizard/swagger/sample/AdminTestResource.java
@@ -11,9 +11,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/test")
+@Path("/hello-admin")
 @Produces(MediaType.APPLICATION_JSON)
-@Api(value = "Test")
+@Api(value = "Admin Test")
 @AdminOnly
 public class AdminTestResource {
 
@@ -23,12 +23,12 @@ public class AdminTestResource {
     @GET
     @Timed
     @ApiOperation(
-        value = "says hello",
+        value = "says hello admin",
         response = Object.class
     )
     public Response sayHello(@QueryParam("name") String name) {
         return Response.ok(new Object(){
-            public final String helloMessage = "Hello " + name;
+            public final String helloMessage = "Hello admin " + name;
         }).build();
     }
 }

--- a/src/test/java/io/paradoxical/dropwizard/swagger/sample/App.java
+++ b/src/test/java/io/paradoxical/dropwizard/swagger/sample/App.java
@@ -5,7 +5,6 @@ import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.paradoxical.dropwizard.bundles.admin.AdminBundle;
-import io.paradoxical.dropwizard.bundles.admin.AdminEnvironmentConfigurator;
 import io.paradoxical.dropwizard.bundles.admin.AdminResourceEnvironment;
 import io.paradoxical.dropwizard.swagger.AdminSwaggerConfiguration;
 import io.paradoxical.dropwizard.swagger.AppSwaggerConfiguration;
@@ -13,21 +12,31 @@ import io.paradoxical.dropwizard.swagger.SwaggerFilters;
 import io.paradoxical.dropwizard.swagger.SwaggerUIConfigurator;
 import io.paradoxical.dropwizard.swagger.bundles.SwaggerUIAdminAssetsBundle;
 import io.paradoxical.dropwizard.swagger.bundles.SwaggerUIBundle;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.BasicAuthDefinition;
+import io.swagger.models.auth.SecuritySchemeDefinition;
 
 import javax.ws.rs.Path;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
 
 public class App extends Application<Config> {
-    public static void main(String ...args) throws Exception {
+    public static void main(String... args) throws Exception {
         new App().run("server", "conf.yml");
     }
+
 
     @Override
     public void initialize(Bootstrap<Config> bootstrap) {
         bootstrap.setConfigurationSourceProvider(new ResourceConfigurationSourceProvider());
 
         bootstrap.addBundle(
-            new SwaggerUIBundle(
-                SwaggerUIConfigurator.forConfig(env -> {
+                new SwaggerUIBundle(env -> {
                     return new AppSwaggerConfiguration(env) {
                         {
                             setTitle("My API");
@@ -40,15 +49,16 @@ public class App extends Application<Config> {
                             setLicenseUrl("http://www.apache.org/licenses/LICENSE-2.0.html");
 
                             setContact("admin@paradoxical.com");
+                            setFilters(SwaggerFilters.withoutAnnotation(AdminOnly.class));
 
                             setVersion("1.0");
                         }
                     };
-                })));
+                }));
 
         bootstrap.addBundle(new SwaggerUIAdminAssetsBundle());
 
-        final SwaggerUIConfigurator adminConfigurator = SwaggerUIConfigurator.forConfig(env -> {
+        final SwaggerUIConfigurator adminSwaggerConfigurator = new SwaggerUIConfigurator(env -> {
             return new AdminSwaggerConfiguration("/admin") {
                 {
                     setTitle("My Admin API");
@@ -62,17 +72,21 @@ public class App extends Application<Config> {
 
                     setContact("admin@paradoxical.com");
 
-                    setFilters(SwaggerFilters.withAnnotation(Path.class));
+                    setFilters(SwaggerFilters.withAnnotation(AdminOnly.class));
 
                     setVersion("1.0");
                 }
             };
+        }, new Swagger() {
+            {
+                addSecurityDefinition("test", new BasicAuthDefinition());
+            }
         });
 
         final AdminBundle adminBundle =
-            AdminBundle.builder()
-                       .configureEnvironment(AdminEnvironmentConfigurator.forJersey(adminConfigurator::configure))
-                       .build();
+                AdminBundle.builder()
+                           .configureEnvironment(adminSwaggerConfigurator)
+                           .build();
 
         bootstrap.addBundle(adminBundle);
     }


### PR DESCRIPTION
Swagger.Core has a painful setup of the `Swagger` model, expecting it
to be configured on the `ServletContext` (which is ugly and annoying to
do in dropwizard)
I’ve added a convenience constructor to pass in a default `Swagger`
model.

Also cleaned up a lot of the documentation, and removed the
`SwagerUIConfigurator.forConfig` methods, which i found to be more
annoying then useful, and moved them to just be straight constructors.
